### PR TITLE
Fix sh to bash for WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ sh setup.sh
 ```
 or, curl
 ```sh
-sh -c "`curl -fsSL https://raw.github.com/ridhwaans/dotfiles/master/remote-setup.sh`"
+bash -c "`curl -fsSL https://raw.github.com/ridhwaans/dotfiles/master/remote-setup.sh`"
 ```
 or, wget
 ```sh
-sh -c "`wget -O - --no-check-certificate https://raw.githubusercontent.com/ridhwaans/dotfiles/master/remote-setup.sh`"
+bash -c "`wget -O - --no-check-certificate https://raw.githubusercontent.com/ridhwaans/dotfiles/master/remote-setup.sh`"
 ```
 
 ## todo


### PR DESCRIPTION
on WSL, sh doesn't have curl installed. with bash, it does. 